### PR TITLE
README changes + fix of AWS Glue continuous logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ This repository contains the practical exercise of the Data Derp training. It co
 5. Fix the tests in `data-ingestion/` and `data-transformation` (in that order). See [Development Environment](./development-environment.md) for tips and tricks on running python/tests in the dev-container.
 
 ## Mirror the Repository
-1. Start importing a repository in your Github account:  
+1. Start importing a repository in your Github account:
 ![import-menu](./assets/import-menu.png)
 
-2. Import the `https://github.com/kelseymok/data-derp` as a **PRIVATE** repo called `data-derp`: 
+2. Import the `https://github.com/kelseymok/data-derp` as a **PRIVATE** repo called `data-derp`:
 ![import-form](./assets/import-form.png)
 
 3. Clone the new repo locally and add the original repository as a source:

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -1,9 +1,10 @@
 # Bootstrap
 This directory holds a single Cloudformation template to set up the following
 * A Single VPC, NAT Gateway, IG, Private/Public Subnet, VPC Endpoints to ensure private networking
-* GithubRunner attached to your specified Github repository 
+* GithubRunner attached to your specified Github repository
 * Terraform Remote State S3 Bucket and DynamoDB
 * S3 bucket containing the exercise's data to be ingested and transformed
+* Spark UI History server instance and S3 bucket to analyze Spark DAGs, stages, executor and driver utilization metrics, etc. 
 
 ## Setup
 1. [Create a Github Personal Access Token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with the Repo Scope. This will be used to generate a token to register a GithubRunner.

--- a/bootstrap/aws-deps-stack/template.yaml
+++ b/bootstrap/aws-deps-stack/template.yaml
@@ -480,6 +480,7 @@ Resources:
       ToPort: 443
       GroupId: !Ref RunnerSecurityGroup
       CidrIp: "0.0.0.0/0"
+
   InstanceRole:
     Type: AWS::IAM::Role
     Properties:
@@ -546,6 +547,7 @@ Resources:
     Properties:
       Roles:
         - !Ref InstanceRole
+
   Boundary:
     Type: AWS::IAM::ManagedPolicy
     #    DeletionPolicy: Retain
@@ -571,6 +573,7 @@ Resources:
             Condition:
               ForAnyValue:StringLike:
                 iam:PassedToService: "ecs-tasks.amazonaws.com"
+
   Role:
     Type: AWS::IAM::Role
     #    DeletionPolicy: Retain
@@ -701,6 +704,7 @@ Resources:
                   - "iam:GetServiceLinkedRoleDeletionStatus"
                 Resource:
                   - "*"
+
   Bucket:
     Type: AWS::S3::Bucket
     Properties:
@@ -722,6 +726,7 @@ Resources:
         BlockPublicAcls: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+
   Table:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -740,6 +745,7 @@ Resources:
           Value: !Ref ProjectName
         - Key: Module
           Value: !Ref ModuleName
+
   DataSourceBucket:
     Type: AWS::S3::Bucket
     Properties:
@@ -759,6 +765,7 @@ Resources:
         BlockPublicAcls: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+
   SparkUiHistoryServerInstance:
     Type: AWS::EC2::Instance
     Properties:
@@ -893,14 +900,17 @@ Resources:
               command: !Sub |
                 curl --retry 60 --retry-delay 10 --retry-max-time 600 --retry-connrefused http://localhost:${HistoryServerPort} --insecure;
                 /opt/aws/bin/cfn-signal -e $? "${SparkUiWaitHandle}"
+
   SparkUiWaitHandle:
     Type: AWS::CloudFormation::WaitConditionHandle
+
   SparkUiWaitCondition:
     Type: AWS::CloudFormation::WaitCondition
     DependsOn: SparkUiHistoryServerInstance
     Properties:
       Handle: !Ref SparkUiWaitHandle
       Timeout: 1200
+
   SparkUiInstanceSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -952,12 +962,14 @@ Resources:
         - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
         - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
         - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+
   SparkUiHistoryServerInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:
       Path: "/"
       Roles:
         - !Ref SparkUiHistoryServerRole
+
   SparkLogsBucket:
     Type: AWS::S3::Bucket
     Properties:

--- a/data-ingestion/README.md
+++ b/data-ingestion/README.md
@@ -5,7 +5,7 @@ This repository creates an AWS Glue job using the logic in the `/src` directory
 It is good practice to ingest data as-is (close to) as it can be expensive to ingest all of the data for every downstream transformation. It is also easier to debug.
 
 Ingest input csv files and output them as parquet to specified locations:
-- Make sure that Spark properly uses the csv header and separator 
+- Make sure that Spark properly uses the csv header and separator
 - Make sure that column names are compatible with Apache Parquet
 
 ## Quickstart

--- a/terraform-modules/glue-job/main.tf
+++ b/terraform-modules/glue-job/main.tf
@@ -81,7 +81,7 @@ data "aws_iam_policy_document" "kms" {
     ]
     resources = [
       "arn:aws:logs:*:*:/aws-glue/*",
-      aws_cloudwatch_log_group.this.arn
+      "${aws_cloudwatch_log_group.this.arn}:*"
     ]
   }
 }


### PR DESCRIPTION
Changes:
- remove extra spaces from README files
- add info about Spark History server to the bootstrap readme file
- Add spaces between blocks in CF template to improve readability
- Fix of resource ARN to make AWS Glue continuous logging work